### PR TITLE
:ambulance: Homebridge: Invlid generated PIN

### DIFF
--- a/homebridge/files/run.sh
+++ b/homebridge/files/run.sh
@@ -156,7 +156,7 @@ generate_homekit_pin() {
 
   pin=$(< /dev/urandom tr -dc 0-9 | head -c3)
   pin+="-"
-  pin+=-$(< /dev/urandom tr -dc 0-9 | head -c2)
+  pin+=$(< /dev/urandom tr -dc 0-9 | head -c2)
   pin+="-"
   pin+=$(< /dev/urandom tr -dc 0-9 | head -c3)
 


### PR DESCRIPTION
## Proposed Changes

Fixes an issue with invalid generated HomeKit PIN codes.

## Related Issues

Fixed [#3 Homebridge pin generated with additional dash](#3)
