### PR TITLE
✨ Adds Network UPS Tools add-on

### DIFF
--- a/.hassio-addons.yml
+++ b/.hassio-addons.yml
@@ -57,6 +57,10 @@ addons:
     repository: hassio-addons/addon-node-red
     target: node-red
     image: hassioaddons/node-red-{arch}
+  nut:
+    repository: hassio-addons/addon-nut
+    target: nut
+    image: hassioaddons/nut
   octobox:
     repository: hassio-addons/addon-octobox
     target: octobox


### PR DESCRIPTION
# Proposed Changes

> This PR will add the [Network UPS Tools](https://github.com/hassio-addons/addon-nut) add-on to the stable repository.

## Related Issues

> N/A