### PR TITLE
Updated zwave2mqtt to version 1.1.3

### DIFF
--- a/zwave2mqtt/config.json
+++ b/zwave2mqtt/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Z-Wave to MQTT",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "slug": "zwave2mqtt",
   "description": "Fully configurable Z-Wave to MQTT gateway and control panel",
   "url": "https://github.com/hassio-addons/addon-zwave2mqtt",


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Upstream version of ZWave2Mqtt is updated to 1.1.3.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/