### PR TITLE
Added SNMP port as an option.

### DIFF
--- a/unifi/config.json
+++ b/unifi/config.json
@@ -19,6 +19,7 @@
   ],
   "boot": "auto",
   "ports": {
+    "161/udp": null,
     "1900/udp": null,
     "3478/udp": 3478,
     "6789/tcp": 6789,
@@ -29,6 +30,7 @@
     "10001/udp": 10001
   },
   "ports_description": {
+    "161/udp": "Used for SNMP Access",
     "1900/udp": "L2 discoverable port",
     "3478/udp": "Used for STUN",
     "6789/tcp": "Used for UniFi mobile speed test",


### PR DESCRIPTION
Some might use this as I do in my external monitoring application.

# Proposed Changes

> Add port 161 as an option, not enabled by default. Whoever wants to use must find a open port they want to use.

## Related Issues

> None

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/