### PR TITLE
:sparkles: use ingress for unifi controller

### DIFF
--- a/unifi/config.json
+++ b/unifi/config.json
@@ -4,6 +4,8 @@
   "slug": "unifi",
   "description": "Manage your UniFi network using a web browser",
   "url": "https://github.com/hassio-addons/addon-unifi",
+  "ingress": true,
+  "ingress_port": 0,
   "webui": "https://[HOST]:[PORT:8443]",
   "startup": "services",
   "arch": [


### PR DESCRIPTION
# Proposed Changes

This switches the unifi controller addon to use a proxy through homeassistant. This avoids people having to open more ports, which is especially annoying when routing through cloudflare or a similar service.