### PR TITLE
fix: correct naming for Zwavejs2Mqtt

### DIFF
--- a/zwavejs2mqtt/DOCS.md
+++ b/zwavejs2mqtt/DOCS.md
@@ -1,6 +1,6 @@
-# Home Assistant Community Add-on: Z-Wave JS to MQTT
+# Home Assistant Community Add-on: Zwavejs2Mqtt
 
-The Z-Wave JS to MQTT add-on allows you to decouple your Z-Wave network from
+The Zwavejs2Mqtt add-on allows you to decouple your Z-Wave network from
 your Home Assistant instance by leveraging your MQTT broker. It ships with
 a web-based control panel, allowing you to configure every aspect of your
 Z-Wave network and how they are published in MQTT.
@@ -22,10 +22,10 @@ This add-on uses the [Zwavejs2Mqtt][zwavejs2mqtt] software.
 The installation of this add-on is pretty straightforward and not different in
 comparison to installing any other Home Assistant add-on.
 
-1. Search for the "Z-Wave JS to MQTT" add-on in the Supervisor add-on store
+1. Search for the "Zwavejs2Mqtt" add-on in the Supervisor add-on store
    and install it.
-1. Start the "Z-Wave JS to MQTT" add-on.
-1. Check the logs of the "Z-Wave JS to MQTT" add-on to see if everything went
+1. Start the "Zwavejs2Mqtt" add-on.
+1. Check the logs of the "Zwavejs2Mqtt" add-on to see if everything went
    well.
 1. Click the "OPEN WEB UI" button.
 1. Enjoy the add-on!
@@ -49,7 +49,7 @@ Home Assistant.
 
 To do this:
 
-1. Open the Z-Wave JS to MQTT control panel by clikcing the "OPEN WEB UI"
+1. Open the Zwavejs2Mqtt control panel by clikcing the "OPEN WEB UI"
    button on the add-on page in the Supervisor.
 1. In the control panel, go to "Settings" in the menu and click on the "Zwave"
    bar that shows up on the right.
@@ -102,7 +102,7 @@ you are troubleshooting.
 
 ## Known issues and limitations
 
-- Z-Wave JS to MQTT supports Home Assistant Discovery over MQTT. It is
+- Zwavejs2Mqtt supports Home Assistant Discovery over MQTT. It is
   **STRONGLY** recommended **NOT** to use that option. Use the Z-Wave JS
   integration as documented above instead.
 

--- a/zwavejs2mqtt/README.md
+++ b/zwavejs2mqtt/README.md
@@ -1,4 +1,4 @@
-# Home Assistant Community Add-on: Z-Wave JS to MQTT
+# Home Assistant Community Add-on: Zwavejs2Mqtt
 
 [![Release][release-shield]][release] ![Project Stage][project-stage-shield] ![Project Maintenance][maintenance-shield]
 
@@ -8,13 +8,13 @@
 
 [![Support Frenck on Patreon][patreon-shield]][patreon]
 
-Fully configurable Z-Wave JS to MQTT gateway and control panel.
+Fully configurable Zwavejs2Mqtt gateway and control panel.
 
-![Z-Wave JS to MQTT][logo]
+![Zwavejs2Mqtt][logo]
 
 ## About
 
-The Z-Wave JS to MQTT add-on allows you to decouple your Z-Wave network from
+The Zwavejs2Mqtt add-on allows you to decouple your Z-Wave network from
 your Home Assistant instance by leveraging your MQTT broker. It ships with
 a web-based control panel, allowing you to configure every aspect of your
 Z-Wave network and how they are published in MQTT.

--- a/zwavejs2mqtt/config.yaml
+++ b/zwavejs2mqtt/config.yaml
@@ -13,7 +13,7 @@ ingress_stream: true
 init: false
 map:
 - share:rw
-name: Z-Wave JS to MQTT
+name: Zwavejs2Mqtt
 panel_icon: mdi:z-wave
 panel_title: Z-Wave JS
 ports:

--- a/zwavejs2mqtt/config.yaml
+++ b/zwavejs2mqtt/config.yaml
@@ -4,7 +4,7 @@ arch:
 - armhf
 - armv7
 - i386
-description: Fully configurable Z-Wave JS to MQTT gateway and control panel
+description: Fully configurable Z-Wave MQTT gateway and control panel, using the Z-Wave JS driver
 discovery:
 - zwave_js
 image: ghcr.io/hassio-addons/zwavejs2mqtt/{arch}


### PR DESCRIPTION
# Proposed Changes

This PR corrects the naming for Zwavejs2Mqtt to match the naming used at the project itself. We don't use Z-Wave JS to MQTT... I think I got everywhere they'd list but I may be missing something as I'm not sure how the AddOn store works.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/