### PR TITLE
Update esphome to 2021.12.3

### DIFF
--- a/esphome/config.json
+++ b/esphome/config.json
@@ -38,5 +38,5 @@
   "slug": "esphome",
   "uart": true,
   "url": "https://esphome.io/",
-  "version": "2021.12.1"
+  "version": "2021.12.3"
 }


### PR DESCRIPTION
# Proposed Changes

Update esphome to 2021.12.3, since version 2021.12.2 was broken on hassio systems

## Related Issues

https://github.com/esphome/issues/issues/2874