### PR TITLE
Mark ESPHome addon as deprecated

### DIFF
--- a/esphome/README.md
+++ b/esphome/README.md
@@ -1,10 +1,12 @@
 # ESPHome Home Assistant Add-On
 
-[![ESPHome logo](https://raw.githubusercontent.com/esphome/hassio/main/esphome-dev/logo.png)](https://esphome.io/)
+# This Add-on is Deprecated
 
-[![GitHub stars](https://img.shields.io/github/stars/esphome/esphome.svg?style=social&label=Star&maxAge=2592000)](https://github.com/esphome/esphome)
-[![GitHub Release][releases-shield]][releases]
-[![Discord][discord-shield]][discord]
+Please add the ESPHome repo https://github.com/esphome/home-assistant-addon and install the ESPHome add-on from there to continue getting updates.
+
+[![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fesphome%2Fhome-assistant-addon)
+
+[![Open your Home Assistant instance and show the dashboard of a Supervisor add-on.](https://my.home-assistant.io/badges/supervisor_addon.svg)](https://my.home-assistant.io/redirect/supervisor_addon/?addon=5c53de3b_esphome)
 
 ## About
 

--- a/esphome/config.json
+++ b/esphome/config.json
@@ -8,7 +8,7 @@
   "backup_exclude": [
     "*/*/"
   ],
-  "description": "ESPHome add-on for intelligently managing all your ESP8266/ESP32 devices",
+  "description": "DEPRECATED - ESPHome",
   "hassio_api": true,
   "host_network": true,
   "image": "esphome/esphome-hassio-{arch}",

--- a/esphome/config.json
+++ b/esphome/config.json
@@ -36,6 +36,7 @@
     "streamer_mode": "bool?"
   },
   "slug": "esphome",
+  "stage": "deprecated",
   "uart": true,
   "url": "https://esphome.io/",
   "version": "2022.3.1"


### PR DESCRIPTION
# Proposed Changes

> Deprecating the ESPHome addon from this repository as announced in the February Release.

- https://github.com/esphome/home-assistant-addon/pull/51

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/