### PR TITLE
Update changelogs of Node-RED and AppDaemon

### DIFF
--- a/appdaemon/CHANGELOG.md
+++ b/appdaemon/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## What’s changed
 
+⚠️ With this release, the `appdaemon` data folder will migrate/move out of the Home Assistant configuration folder into a dedicated folder for this add-on. You can access add-on configuration folders using SSH, Samba, VSCode, and similar add-ons by accessing the `addon_configs` folder/share.
+
+If you have this in your `appdaemon.yaml` file:
+
+```yaml
+secrets: /config/secrets.yaml
+```
+
+You will need to adjust this to:
+
+```yaml
+secrets: /homeassistant/secrets.yaml
+```
+
 ## 🐛 Bug fixes
 
 - Fixed another incorrect check @frenck ([#290](https://github.com/hassio-addons/addon-appdaemon/pull/290))

--- a/node-red/CHANGELOG.md
+++ b/node-red/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## What’s changed
 
+⚠️ With this release, the `nodered` data folder will migrate/move out of the Home Assistant configuration folder into a dedicated folder for this add-on. You can access add-on configuration folders using SSH, Samba, VSCode, and similar add-ons by accessing the `addon_configs` folder/share.
+
 ## 🐛 Bug fixes
 
 - Fix incorrect check for existing files @frenck ([#1738](https://github.com/hassio-addons/addon-node-red/pull/1738))


### PR DESCRIPTION
# Proposed Changes

> This updates the CHANGELOG.md files of the node-red and appdaemon add-ons to match the release notes of these.
> I know this change will not stick and will be overwritten on the next release of these.
> However, the supervisor uses these files to show the content; currently, the updated information is hidden.

Example:
![image](https://github.com/hassio-addons/repository/assets/15093472/1ada9c5b-896b-45ac-af6d-6aec7f54b495)


## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/