### PR TITLE
Point the Overseerr entry at the renamed Seerr app

### DIFF
--- a/.apps.yml
+++ b/.apps.yml
@@ -94,9 +94,9 @@ apps:
     target: nut
     image: ghcr.io/hassio-addons/nut
   overseerr:
-    repository: hassio-addons/addon-overseerr
-    target: overseerr
-    image: ghcr.io/hassio-addons/overseerr/{arch}
+    repository: hassio-addons/app-seerr
+    target: seerr
+    image: ghcr.io/hassio-addons/overseerr
   phpmyadmin:
     repository: hassio-addons/addon-phpmyadmin
     target: phpmyadmin


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Overseerr is no longer developed. Upstream merged it with Jellyseerr into a single project called [Seerr](https://seerr.dev), and the app repository follows that rename. This updates the stable index accordingly.

```diff
   overseerr:
-    repository: hassio-addons/addon-overseerr
-    target: overseerr
-    image: ghcr.io/hassio-addons/overseerr/{arch}
+    repository: hassio-addons/app-seerr
+    target: seerr
+    image: ghcr.io/hassio-addons/overseerr
```

Three fields change, and one deliberately does not:

- The key stays `overseerr`. That is the slug, kept on purpose so Home Assistant treats this as an ordinary update, the existing configuration directory is preserved, and Seerr migrates the settings, users and requests in place on first start. Changing it would have made this a new app and left every existing user to move their data by hand. This is the same shape as the `bitwarden` entry, which points at `hassio-addons/app-vaultwarden` with `target: vaultwarden`.
- `repository` follows the repository rename to `hassio-addons/app-seerr`.
- `target` follows the app directory rename to `seerr`. The slug is read from `config.yaml` rather than derived from the directory name, so the two are free to differ.
- `image` drops `{arch}`, because the app now builds through the app workflows, which publish a multi arch manifest alongside the per architecture images. All 22 `app-*` entries in this index are already written without `{arch}`, and all 24 `addon-*` entries still carry it.

Note on the `image` field: the currently published stable version, 0.1.0, only exists as per architecture images, so `ghcr.io/hassio-addons/overseerr:0.1.0` does not resolve today. That is fine, because the repository updater only runs on a `repository_dispatch`, so merging this regenerates nothing. It takes effect at the next stable release, which is built by the app workflows and does produce the manifest.

### Merge order

This depends on two things happening first:

1. hassio-addons/addon-overseerr#48 merged, which is what renames the app directory to `seerr`.
2. The GitHub repository renamed from `addon-overseerr` to `app-seerr`. Until that happens, `hassio-addons/app-seerr` does not resolve.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

hassio-addons/addon-overseerr#48, which fixes hassio-addons/addon-overseerr#33.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Overseerr app source and image configuration to improve app availability and compatibility across supported systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->