### PR TITLE
:sparkles: Add Spotweb to app store

### DIFF
--- a/.apps.yml
+++ b/.apps.yml
@@ -129,6 +129,10 @@ apps:
     repository: hassio-addons/addon-spotify-connect
     target: spotify
     image: ghcr.io/hassio-addons/spotify/{arch}
+  spotweb:
+    repository: hassio-addons/app-spotweb
+    target: spotweb
+    image: ghcr.io/hassio-addons/spotweb
   prowlarr:
     repository: hassio-addons/addon-prowlarr
     target: prowlarr


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Adds the new Spotweb app to the store.

Spotweb is a decentralized usenet community built on the Spotnet protocol. It retrieves the "spots" other people post to usenet, indexes them into a searchable database, and serves a web interface to browse them, keep a watchlist, follow or blacklist the people posting, and hand the NZB files it finds to a download client. It also exposes a Newznab compatible API, which is what lets Sonarr, Radarr and Prowlarr treat it as an indexer.

The first thing to settle was what to build from. Spotweb has not tagged a release since 1.5.8 in December 2024, and its master branch has been dormant since February 2025. All of the actual development happens on `develop`, which is still moving. So the app tracks `develop`, pinned to an exact commit rather than following the branch head, which is the difference between a reproducible build and whatever happened to be there that morning. Renovate keeps it current through the `git-refs` datasource with a captured `currentDigest`. Upstream commits to `develop` on roughly 11 to 22 distinct days a year, so that is a manageable trickle rather than a flood. The digest deliberately does not automerge: `develop` is work in progress, and a bump has no release notes to read.

Alpine, with `php84`. The Spotweb wiki caps supported PHP at 8.4, so this does not follow Grocy and BookStack onto `php85`. Every extension Spotweb's own installer checks for exists in Alpine 3.24 community. `vendor/` is committed upstream, so there is no Composer step in the build.

Data lives in SQLite in the app's data directory. Upstream calls SQLite its least tested backend, and it is the honest trade for an app that should work the moment it is installed, with no MariaDB app to set up first. The on-disk cache is symlinked into `/data` rather than pointed there through the `cache_path` setting, because `bin/upgrade-db.php` assumes that setting starts with `./` when it clears the cache.

Ingress turned out clean. Spotweb renders an absolute `<base href>` derived from the forwarded host, protocol and URI, so the Ingress server block feeds it `$http_x_forwarded_host`, `$http_x_forwarded_proto` and `$http_x_ingress_path`, and everything else in its templates is already relative. Verified against the built image: the base href comes back as the Ingress entry point, and CSS and JS both load through it.

Two upstream quirks needed handling, both of which only bite on a first install:

A fresh database needs more than one pass of `bin/upgrade-db.php`. The first creates the schema, and only once those tables exist can the settings and security versions be written, which are exactly what Spotweb checks before it will serve a page. The init loops until Spotweb reports itself ready rather than hardcoding a number of passes.

More seriously, the default `admin` / `admin` login does not work on a fresh install. `bin/upgrade-db.php` creates its users before it creates the settings, and the password salt is one of those settings, so the admin account is hashed against a salt that does not exist yet and nothing ever matches it. Spotweb's own installation wizard sidesteps this by creating the settings first, but the wizard is not usable here since it refuses to run against a configured installation. The init repairs it by setting the password once the salt is in place, through Spotweb's own `resetUserPassword`. An `admin_password` option feeds into the same path, applied only when the configured value changes so a password changed from within Spotweb is not overwritten on every restart.

Retrieval runs on a configurable interval and is gated on a usenet server actually being configured. `retrieve.php` exits 0 even when there is no server to talk to, after printing a stack trace, so without the gate the log would collect a trace every interval until somebody filled out the settings.

Ingress is the primary way in, and the port is opt in for the cases Ingress cannot serve: the Newznab API that the *arr apps consume, and pushing NZB files to an external download client, both of which need an address that works outside a Home Assistant session. The installation wizard, the library code, the bundled dependencies, the console scripts and the cached NZB files and images are all closed off over HTTP.

Verified end to end against the built image: fresh install and idempotent restart, Ingress and direct rendering, static assets, the Newznab API rewrite that upstream ships as an `.htaccess` rule, custom and default admin logins, and the denied paths. hadolint, shellcheck and yamllint are clean, and CI on the app repository passed on the first run including both architecture builds.

It builds for aarch64 and amd64, and lives at https://github.com/hassio-addons/app-spotweb

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Spotweb as an available app.
  * Configured the app to use its official repository and container image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->