### PR TITLE
:sparkles: Add FreshRSS to app store

### DIFF
--- a/.apps.yml
+++ b/.apps.yml
@@ -49,6 +49,10 @@ apps:
     repository: hassio-addons/addon-foldingathome
     target: foldingathome
     image: ghcr.io/hassio-addons/foldingathome/{arch}
+  freshrss:
+    repository: hassio-addons/app-freshrss
+    target: freshrss
+    image: ghcr.io/hassio-addons/freshrss
   ftp:
     repository: hassio-addons/addon-ftp
     target: ftp


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Adds the new FreshRSS app to the store.

FreshRSS is a self-hosted RSS and Atom feed aggregator. It collects the feeds you subscribe to, keeps track of what you have read, and lets you search, label and filter your way through them. It refreshes on a schedule, so what you open is already waiting for you, and it speaks the Google Reader and Fever protocols, which is what lets mobile readers like Reeder, FeedMe, Fluent Reader and NetNewsWire sync against it.

Alpine, with `php84`. That is not the newest PHP in Alpine 3.24, and the choice is deliberate: there is no `php85-opcache` package there, while `php84-opcache` exists, and FreshRSS lists `ext-zend-opcache` in its own requirements. It is also what upstream ships in `Docker/Dockerfile-Alpine`, their supported image; `php85` only appears in `Dockerfile-Newest`, which is their forward-looking test build. Every extension FreshRSS actually loads exists in Alpine 3.24 community. Dependencies are vendored into `lib/` upstream, so there is no Composer step in the build.

SQLite, and only SQLite. It is a supported backend upstream rather than a tolerated one, and it is the honest trade for an app that should work the moment it is installed, with no MariaDB app to set up first. Everything FreshRSS persists is relocated below `/data` through `constants.local.php`, which is upstream's own extension point for exactly this. Extensions installed from within FreshRSS are put there too, rather than next to the application, so that they survive an app update that replaces the whole application directory.

Ingress turned out cleaner than expected. `Minz_Url` emits relative URLs, and `Minz_Request::extractPrefix()` already reads `X-Forwarded-Prefix`, so the Ingress server block only has to map `$http_x_ingress_path` onto that one header. No HTML rewriting, no `sub_filter`, nothing to keep in step with an upstream template. `base_url` is deliberately left empty so the address is worked out per request, since Home Assistant hands out a different Ingress path per session.

One thing did need fixing for Ingress to work at all: FreshRSS ships a Content-Security-Policy of `frame-ancestors 'none'`, which no iframe survives, same origin or not. Left alone it renders as a blank panel. It is a configuration key, so the init widens it to `'self'`, which is exactly as far as it needs to go, since Ingress serves the app from below the root of the Home Assistant origin.

Signing in is where this app makes a real choice. Home Assistant has already established who is asking by the time a request reaches Ingress, so by default FreshRSS is told to take that word for it and the sidebar drops you straight into your feeds with no second login. The account name is injected as `REMOTE_USER` rather than through the `X-WebAuth-User` or `Remote-User` headers that FreshRSS also accepts. That is the security-relevant detail: NGINX prefixes every incoming request header with `HTTP_`, so nothing a browser sends can ever land in `REMOTE_USER`, and it needs no widening of FreshRSS' `trusted_sources`. The two header variants are additionally cleared with empty `fastcgi_param` values, which makes NGINX drop the incoming header rather than pass it on.

The trade is that with auto login on, the published port serves the API but not the web interface, because FreshRSS has a single `auth_type` for the whole installation and there is no login form to fall back on. An `ingress_auto_login` option switches the whole thing back to normal form login for people who want the port usable from a browser, or more than one account. The Google Reader and Fever APIs authenticate on a per-user API password and are unaffected either way.

Two bugs were found and fixed while verifying against the built image, both of which would have shipped silently:

`cli/do-install.php` was being handed `--disable-update true`. FreshRSS parses with `getopt()`, which takes no separate argument for an option whose value is optional and stops reading at the first thing that is not an option, so `true` ended the argument list and `--allow-robots` and `--disable-update` were dropped without a word of complaint. Everything now uses the `--opt=value` form, confirmed against `getopt()` directly.

The SSL branch of the direct server used `listen ... http2`, which NGINX 1.30 deprecates and warns about on every start. It now uses the `http2 on;` directive, verified to still negotiate HTTP/2.

Verified end to end against the built image, on an isolated network with a stubbed Supervisor: fresh install, idempotent restart, and the option toggles in both directions. Over Ingress the root redirect comes back carrying the Ingress path, the app returns 200 with `frame-ancestors 'self'`, and the admin-only pages are reachable, which is what proves the auto login landed on the right account. Spoofed `X-WebAuth-User`, `Remote-User` and `X-Forwarded-Prefix` headers were all confirmed absent from the CGI environment. The Google Reader API gets its `PATH_INFO` and answers 401 on bad credentials rather than the "Bad Request" that a missing split produces. Form login, password rotation through the change stamp, HTTPS on the direct port, static asset serving with cache headers, and the denied paths were all exercised too. hadolint is clean and the app repository's CI passed including both architecture builds.

It builds for aarch64 and amd64, and lives at https://github.com/hassio-addons/app-freshrss

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FreshRSS to the available app catalog.
  * Configured the FreshRSS app image and deployment target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->