### PR TITLE
:sparkles: Add Stirling PDF to app store

### DIFF
--- a/.apps.yml
+++ b/.apps.yml
@@ -177,6 +177,10 @@ apps:
     repository: hassio-addons/app-sqlite-web
     target: sqlite-web
     image: ghcr.io/hassio-addons/sqlite-web
+  stirling-pdf:
+    repository: hassio-addons/app-stirling-pdf
+    target: stirling-pdf
+    image: ghcr.io/hassio-addons/stirling-pdf
   tor:
     repository: hassio-addons/app-tor
     target: tor


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Adds the new Stirling PDF app to the store.

Opened as a draft on purpose. Stirling PDF goes into edge first and beta after that, and this one is here for when it has earned its way to stable.

Stirling PDF is a workshop for PDFs. Merge, split, rotate, crop and reorder pages; compress a scan that is too large to send; convert to and from Word, Excel, PowerPoint, images, HTML and Markdown; sign, stamp, watermark, fill in a form, or black out what should not have been in there. An OCR pass turns a scanned page from a picture of text into text you can search, which is the difference between a pile of scans and an archive. Nothing leaves the house: the file goes up, is worked on here, and comes back.

Debian, not Alpine, and the choice was not close. Upstream moved off Alpine themselves for v2 and now run on `eclipse-temurin:25-jre-noble`. More to the point, Alpine 3.24 has no `python3-uno` at all, and Stirling PDF routes every office conversion through unoserver, a Python daemon that imports the `uno` module; there is no pyuno subpackage anywhere in main or community, so DOCX, XLSX and PPTX conversion would simply be gone. Debian 13 carries every dependency in stable for both architectures.

The upstream release JAR is used rather than a build from source. It is architecture independent and saves a Gradle 9 plus JDK 25 plus Node 22 toolchain in the image. Specifically `Stirling-PDF.jar`, which is the `DISABLE_ADDITIONAL_FEATURES=true` build. That matters for licensing: `app/proprietary/` in the upstream repository is not MIT, it is the Stirling PDF User License, which requires a paid subscription for production use and forbids redistribution. The `-with-login` JAR compiles that directory in, so shipping it here would be redistributing it. The core build excludes it, and the frontend is built in `core` mode which excludes the matching proprietary frontend directory.

Ingress needed no patches at all, which is unusual for an SPA. Stirling PDF's `ReactRoutingController` writes its own base into every `index.html` it serves, taking the value from the servlet context path, and the frontend is built with a relative Vite base so assets already resolve against `<base href>`. NGINX rewrites the two values that controller emits, and that is the whole of it. Setting `SYSTEM_ROOTURIPATH` to the Ingress path instead would be the obvious move and is wrong: the Supervisor strips the prefix before forwarding, so the application would be listening at a path no request arrives on. It stays at the root and the page is rewritten on the way past.

Since that build has no login of its own, the direct port is guarded by Home Assistant, the same way Node-RED, Glances, AdGuard Home and VictoriaMetrics do it: an NGINX `auth_request` against the Supervisor's `/auth`, with `leave_front_door_open` to turn it off. A browser gets a password prompt, and a script sends the same credentials as Basic auth, which is what makes the REST API usable from a `rest_command`.

Calibre is left out deliberately. It answers for exactly one endpoint, PDF to EPUB, and costs 833MB installed because it brings Qt6 WebEngine and PyQt6 with it, which would have taken the image from 1.6GB to about 2.4GB. `rar` is out too, being non-free and therefore not redistributable, which costs PDF to CBR. Both are switched off by name so they are greyed out rather than offered and then failing.

Verified against the built image rather than assumed. Over Ingress both rewrites land and nothing in the served document is left addressed from the site root. DOCX to PDF, HTML to PDF via WeasyPrint, PDF to PPTX, compression, and a real OCR round trip all produce valid output; an image-only PDF with no text came back searchable. The whole thing was booted under S6 against a mock Supervisor: services start in order, state lands in `/data`, the Ingress port refuses anything that is not the Supervisor, and the health check passes. The direct port was checked in both states, guarded and open, including that NGINX forwards the `WWW-Authenticate` header so a browser actually gets a prompt. Dropping a `deu.traineddata` into the config folder made Tesseract report it on the next start.

Two things the startup dependency probe caught that would otherwise have shipped: ImageMagick missing, which is the image path through Compress PDF, and FontForge missing, which is Type 3 font conversion. Both added, at 17MB and 13MB. Upstream also installs Xvfb, claiming headless Impress and Draw need it; PPTX conversion works without it here, so it is not in the image and 212MB stayed out.

It builds for aarch64 and amd64, and lives at https://github.com/hassio-addons/app-stirling-pdf

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Stirling PDF to the available app catalog.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->