### PR TITLE
:sparkles: Add Actual Budget to app store

### DIFF
--- a/.apps.yml
+++ b/.apps.yml
@@ -1,6 +1,10 @@
 ---
 channel: stable
 apps:
+  actual-budget:
+    repository: hassio-addons/app-actual-budget
+    target: actual-budget
+    image: ghcr.io/hassio-addons/actual-budget
   adguard:
     repository: hassio-addons/app-adguard-home
     target: adguard


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Adds the new Actual Budget app to the store.

Actual is a local-first envelope budgeting app. This app runs its sync server on Alpine, straight from the published npm package, with NGINX in front for Ingress. Actual is built for the site root and has no base path setting, so the client is patched at build time to resolve everything against the document base instead. Every substitution in that patch asserts its match and fails the build if upstream reshapes the bundle. Verified end to end in a real browser through an emulated Ingress path: password, sign in, budget, navigation and a hard reload on a deep route, with no failed requests.

It builds for aarch64 and amd64, and lives at https://github.com/hassio-addons/app-actual-budget

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Actual Budget app to the available app catalog.
  - Configured its associated repository and container image for deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->