### PR TITLE
:sparkles: Add Dispatcharr to app store

### DIFF
--- a/.apps.yml
+++ b/.apps.yml
@@ -45,6 +45,10 @@ apps:
     repository: hassio-addons/app-chrony
     target: chrony
     image: ghcr.io/hassio-addons/chrony
+  dispatcharr:
+    repository: hassio-addons/app-dispatcharr
+    target: dispatcharr
+    image: ghcr.io/hassio-addons/dispatcharr
   emqx:
     repository: hassio-addons/app-emqx
     target: emqx


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Adds the new Dispatcharr app to the store.

Dispatcharr takes the IPTV subscriptions you already have and turns them into one tidy channel list. Point it at your providers and it pulls in their playlists, works out which of the thousands of streams you actually want, and puts them in the order you choose. Where the same channel comes from several providers it keeps all of them and moves on to the next when one stops working. It matches channels against XMLTV sources or Schedules Direct for a proper guide, and has a DVR that records from it on a schedule. What it hands back is a channel list every media player already understands: a playlist and a guide, and an HDHomeRun tuner emulation that Plex, Emby and Jellyfin discover without being told anything beyond an address.

Ingress took some work. Dispatcharr is a Django backend with a Vite/React frontend that addresses everything from the site root, and under Ingress the site root belongs to Home Assistant. The frontend funnels nearly everything through single choke points (one `host` constant behind all 230 API calls, one `BrowserRouter`, one WebSocket URL builder), so the patch teaches it two separate bases that NGINX writes into the page per request. `SUB_PATH` is the Ingress path this request arrived on, and drives the API calls, the router, the WebSocket and the asset tags. `PUBLIC_URL` is the address on the network, and is what the M3U, EPG and HDHomeRun links in the interface are built from, because those links are for players and media servers, and an Ingress path is tied to a browser session and of no use to a television. Server side, the artwork URLs come back inside JSON payloads where no rewrite can reach them, so the Ingress server hands the path to Django as `SCRIPT_NAME` over the uWSGI protocol and `reverse()` does the rest. A fetch/XHR/img interceptor covers the long tail, with the video player call sites patched by hand because mpegts.js runs its loader in a Web Worker the interceptor cannot reach. Django's default `X-Frame-Options: DENY` is dropped on the Ingress server only, or nothing would render in the iframe at all. Verified end to end through NGINX against the built image: every rewritten tag, both API paths, and the entry chunk served under the prefix.

Port 9191 is published by default, the way Jellyfin's is, because an app that serves streams is not much use with it closed. Ingress is for browsers.

The database is PostgreSQL 17, bundled and socket only. SQLite was the first choice and does not work: three of upstream's migrations run unguarded PostgreSQL SQL, and a fresh SQLite database never finishes migrating. PostgreSQL comes from the project's own apt repository rather than Debian's, so the major version is pinned to the Dockerfile and a base image bump across a Debian release cannot move it out from under existing installations. An init guard refuses to start on a data directory from a different major, with an explanation, and `POSTGRES-UPGRADE.md` in the repository is the procedure for when that day comes. `initdb` pins the locale and enables checksums so a future `pg_upgrade` has nothing to object to.

Upstream depends on PyTorch and sentence-transformers for one optional pass over EPG channel matching, about 2GB of wheels for a feature whose own loader falls back to string matching when the import fails. Both are dropped, and NumPy with them, since nothing else in the tree imports it. Comskip is built from source for the DVR's commercial detection. The image is 1.07GB against upstream's multi-gigabyte all-in-one.

It runs on Debian, builds for aarch64 and amd64, and lives at https://github.com/hassio-addons/app-dispatcharr

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Dispatcharr to the stable application catalog.
  - Configured its associated repository, build target, and application image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->